### PR TITLE
Separated per-gene results from SCE in the dump.

### DIFF
--- a/src/dump/SingleCellExperiment.js
+++ b/src/dump/SingleCellExperiment.js
@@ -90,7 +90,7 @@ function dumpColumnData(state, modality_prefixes, main_modality, all_sce_metadat
     }
 
     if (state.crispr_normalization.valid()) {
-        all_coldata.CRISPR = allcoldata.CRISPR.setColumn("kana::size_factors", state.crispr_normalization.fetchSizeFactors());
+        all_coldata.CRISPR = all_coldata.CRISPR.setColumn("kana::size_factors", state.crispr_normalization.fetchSizeFactors());
     }
 
     {

--- a/src/dump/SingleCellExperiment.js
+++ b/src/dump/SingleCellExperiment.js
@@ -1,7 +1,6 @@
 import * as bioc from "bioconductor";
 import * as df from "./DataFrame.js";
 import * as assay from "./assays.js";
-import * as markers from "./markers.js";
 import * as reddim from "./reducedDimensions.js";
 import * as list from "./List.js";
 
@@ -9,22 +8,36 @@ import * as list from "./List.js";
  ************************************************/
 
 function dumpColumnData(state, modality_prefixes, main_modality, all_sce_metadata, all_other_metadata, all_files, forceBuffer) {
-    let retained = state.cell_filtering.fetchFilteredMatrix().numberOfColumns();
+    let disc = state.cell_filtering.fetchDiscards();
+    let keep = [];
+    if (disc !== null) {
+        disc.forEach((x, i) => {
+            if (!x) { keep.push(i); }
+        });
+    }
 
     let all_coldata = {};
-    for (const m of Object.keys(modality_prefixes)) {
-        all_coldata[m] = new bioc.DataFrame({}, { numberOfRows: retained });
+    {
+        let full = state.inputs.fetchCellAnnotations();
+        all_coldata[main_modality] = (disc === null ? full : bioc.SLICE(full, keep));
+
+        let nrows = all_coldata[main_modality].numberOfRows();
+        for (const k of Object.keys(modality_prefixes)) {
+            if (k !== main_modality) {
+                all_coldata[k] = new bioc.DataFrame({}, { numberOfRows: nrows });
+            }
+        }
     }
 
     // Quality control.
     if (state.rna_quality_control.valid()) {
-        let rdf = new bioc.DataFrame({}, { numberOfRows: retained });
-        rdf.$setColumn("sums", state.cell_filtering.applyFilter(state.rna_quality_control.fetchMetrics().sums({ copy: false })));
-        rdf.$setColumn("detected", state.cell_filtering.applyFilter(state.rna_quality_control.fetchMetrics().detected({ copy: false })));
-        rdf.$setColumn("proportions", state.cell_filtering.applyFilter(state.rna_quality_control.fetchMetrics().subsetProportions(0, { copy: false })));
-        all_coldata.RNA.$setColumn("rna_quality_control", rdf);
+        let rdf = all_coldata.RNA;
+        rdf = rdf.setColumn("kana::quality_control::sums", state.cell_filtering.applyFilter(state.rna_quality_control.fetchMetrics().sums({ copy: false })));
+        rdf = rdf.setColumn("kana::quality_control::detected", state.cell_filtering.applyFilter(state.rna_quality_control.fetchMetrics().detected({ copy: false })));
+        rdf = rdf.setColumn("kana::quality_control::proportions", state.cell_filtering.applyFilter(state.rna_quality_control.fetchMetrics().subsetProportions(0, { copy: false })));
+        all_coldata.RNA = rdf;
 
-        all_other_metadata.RNA["rna_quality_control"] = { 
+        all_other_metadata.RNA["kana::quality_control"] = { 
             "filters": {
                 "sums": state.rna_quality_control.fetchFilters().thresholdsSums(),
                 "detected": state.rna_quality_control.fetchFilters().thresholdsDetected(),
@@ -34,13 +47,13 @@ function dumpColumnData(state, modality_prefixes, main_modality, all_sce_metadat
     }
 
     if (state.adt_quality_control.valid()) {
-        let adf = new bioc.DataFrame({}, { numberOfRows: retained });
-        adf.$setColumn("sums", state.cell_filtering.applyFilter(state.adt_quality_control.fetchMetrics().sums({ copy: false })));
-        adf.$setColumn("detected", state.cell_filtering.applyFilter(state.adt_quality_control.fetchMetrics().detected({ copy: false })));
-        adf.$setColumn("igg_totals", state.cell_filtering.applyFilter(state.adt_quality_control.fetchMetrics().subsetTotals(0, { copy: false })));
-        all_coldata.ADT.$setColumn("adt_quality_control", adf);
+        let adf = all_coldata.ADT;
+        adf = adf.setColumn("kana::quality_control::sums", state.cell_filtering.applyFilter(state.adt_quality_control.fetchMetrics().sums({ copy: false })));
+        adf = adf.setColumn("kana::quality_control::detected", state.cell_filtering.applyFilter(state.adt_quality_control.fetchMetrics().detected({ copy: false })));
+        adf = adf.setColumn("kana::quality_control::igg_totals", state.cell_filtering.applyFilter(state.adt_quality_control.fetchMetrics().subsetTotals(0, { copy: false })));
+        all_coldata.ADT = adf;
 
-        all_other_metadata.ADT["adt_quality_control"] = {
+        all_other_metadata.ADT["kana::quality_control"] = {
             "filters": {
                 "detected": state.adt_quality_control.fetchFilters().thresholdsDetected(),
                 "igg_totals": state.adt_quality_control.fetchFilters().thresholdsSubsetTotals(0)
@@ -49,59 +62,65 @@ function dumpColumnData(state, modality_prefixes, main_modality, all_sce_metadat
     }
 
     if (state.crispr_quality_control.valid()) {
-        let cdf = new bioc.DataFrame({}, { numberOfRows: retained });
-        cdf.$setColumn("sums", state.cell_filtering.applyFilter(state.crispr_quality_control.fetchMetrics().sums({ copy: false })));
-        cdf.$setColumn("detected", state.cell_filtering.applyFilter(state.crispr_quality_control.fetchMetrics().detected({ copy: false })));
-        cdf.$setColumn("max_proportion", state.cell_filtering.applyFilter(state.crispr_quality_control.fetchMetrics().maxProportions({ copy: false })));
-        cdf.$setColumn("max_index", state.cell_filtering.applyFilter(state.crispr_quality_control.fetchMetrics().maxIndex({ copy: false })));
-        all_coldata.CRISPR.$setColumn("crispr_quality_control", cdf);
+        let cdf = all_coldata.CRISPR;
+        cdf = cdf.setColumn("kana::quality_control::sums", state.cell_filtering.applyFilter(state.crispr_quality_control.fetchMetrics().sums({ copy: false })));
+        cdf = cdf.setColumn("kana::quality_control::detected", state.cell_filtering.applyFilter(state.crispr_quality_control.fetchMetrics().detected({ copy: false })));
+        cdf = cdf.setColumn("kana::quality_control::max_proportion", state.cell_filtering.applyFilter(state.crispr_quality_control.fetchMetrics().maxProportions({ copy: false })));
+        cdf = cdf.setColumn("kana::quality_control::max_index", state.cell_filtering.applyFilter(state.crispr_quality_control.fetchMetrics().maxIndex({ copy: false })));
+        all_coldata.CRISPR = cdf;
 
-        all_other_metadata.CRISPR["crispr_quality_control"] = {
+        all_other_metadata.CRISPR["kana::quality_control"] = {
             "filters": {
                 "max_count": state.crispr_quality_control.fetchFilters().thresholdsMaxCount()
             }
         };
     }
 
+    if (disc !== null) {
+        all_coldata[main_modality] = all_coldata[main_modality].setColumn("kana::quality_control::retained_indices", keep);
+    }
+
     // Size Factors.
     if (state.rna_normalization.valid()) {
-        all_coldata.RNA.$setColumn("sizeFactor", state.rna_normalization.fetchSizeFactors());
+        all_coldata.RNA = all_coldata.RNA.setColumn("kana::size_factors", state.rna_normalization.fetchSizeFactors());
     }
 
     if (state.adt_normalization.valid()) {
-        all_coldata.ADT.$setColumn("sizeFactor", state.adt_normalization.fetchSizeFactors());
+        all_coldata.ADT = all_coldata.ADT.setColumn("kana::size_factors", state.adt_normalization.fetchSizeFactors());
     }
 
     if (state.crispr_normalization.valid()) {
-        all_coldata.CRISPR.$setColumn("sizeFactor", state.crispr_normalization.fetchSizeFactors());
-    }
-
-    let disc = state.cell_filtering.fetchDiscards();
-    if (disc !== null) {
-        let keep = [];
-        disc.forEach((x, i) => {
-            if (!x) { keep.push(i); }
-        });
-        all_coldata[main_modality].$setColumn("retained", keep);
+        all_coldata.CRISPR = allcoldata.CRISPR.setColumn("kana::size_factors", state.crispr_normalization.fetchSizeFactors());
     }
 
     {
-        // Incrementing to avoid cluster names starting from 0.
+        // Incrementing to avoid cluster names starting from 0. Note that there's
+        // no need to respect the reportOneIndex setting, as cluster names are
+        // not indices with respect to anything. The only thing they need to match
+        // with is the marker table names, and we increment there (in markers.js) as well.
         let clusters = state.choose_clustering.fetchClusters().map(x => x + 1);
-        all_coldata[main_modality].$setColumn("clusters", clusters);
+        all_coldata[main_modality] = all_coldata[main_modality].setColumn("kana::clusters", clusters);
     }
 
     {
         let block = state.cell_filtering.fetchFilteredBlock();
         if (block !== null) {
-            all_coldata[main_modality].$setColumn("block", block);
-
             let stringy = new Array(block.length);
             let levels = state.inputs.fetchBlockLevels();
             block.forEach((x, i) => { stringy[i] = levels[x]; }); 
-            all_coldata[main_modality].$setColumn("named_block", stringy);
+            all_coldata[main_modality] = all_coldata[main_modality].setColumn("kana::block", stringy);
+        }
+    }
 
-            all_other_metadata[main_modality].block_levels = levels;
+    // Custom selections, stored as boolean arrays.
+    {
+        let customs = state.custom_selections.fetchSelections({ copy: false });
+        let nrows = all_coldata[main_modality].numberOfRows();
+        for (const [v, k] of Object.entries(customs)) {
+            let as_bool = new Uint8Array(nrows);
+            as_bool.fill(0);
+            k.forEach(index => { as_bool[index] = 1; });
+            all_coldata[main_modality] = all_coldata[main_modality].setColumn("kana::custom_selections::" + v, as_bool);
         }
     }
 
@@ -117,48 +136,6 @@ function dumpColumnData(state, modality_prefixes, main_modality, all_sce_metadat
     }
 
     return;
-}
-
-/************************************************
- ************************************************/
-
-function dumpRowData(state, modality_prefixes, main_modality, all_sce_metadata, all_other_metadata, all_files, forceBuffer) {
-    let row_info = state.inputs.fetchFeatureAnnotations();
-
-    let all_rowdata = {};
-    for (const m of Object.keys(modality_prefixes)) {
-        all_rowdata[m] = row_info[m];
-    }
-
-    if ("RNA" in modality_prefixes) {
-        let res = state.feature_selection.fetchResults();
-        let df = new bioc.DataFrame(
-            {
-                mean: res.means({ copy: "view" }),
-                variance: res.variances({ copy: "view" }),
-                fitted: res.fitted({ copy: "view" }),
-                residual: res.residuals({ copy: "view" })
-            }, 
-            { 
-            columnOrder: [ "mean", "variance", "fitted", "residual" ] 
-            }
-        );
-        all_rowdata.RNA = all_rowdata.RNA.setColumn("feature_selection", df);
-    }
-
-    markers.dumpMarkerDetectionResults(state, Object.keys(modality_prefixes), all_rowdata);
-
-    markers.dumpCustomSelectionResults(state, Object.keys(modality_prefixes), main_modality, all_rowdata, all_other_metadata);
-
-    for (const [name, prefix] of Object.entries(modality_prefixes)) {
-        let collected = df.writeHdf5DataFrame(all_rowdata[name], prefix + "rowdata", { forceBuffer });
-        collected.self.metadata.is_child = true;
-        all_sce_metadata[name].summarized_experiment.row_data.resource.path = collected.self.metadata.path;
-        all_files.push(collected.self);
-        for (const x of collected.children) {
-            all_files.push(x);
-        }
-    }
 }
 
 /************************************************
@@ -199,7 +176,7 @@ function mockSingleCellExperimentMetadata(p) {
 /************************************************
  ************************************************/
 
-export async function dumpSingleCellExperiment(state, path, { forceBuffer = false } = {}) {
+export async function dumpSingleCellExperiment(state, path, { reportOneIndex = false, forceBuffer = false } = {}) {
     let row_info = state.inputs.fetchFeatureAnnotations();
 
     let modalities = Object.keys(row_info);
@@ -247,7 +224,18 @@ export async function dumpSingleCellExperiment(state, path, { forceBuffer = fals
     // Saving the column and row data.
     dumpColumnData(state, all_prefixes, main, all_top_meta, all_metadata, all_files, forceBuffer);
 
-    dumpRowData(state, all_prefixes, main, all_top_meta, all_metadata, all_files, forceBuffer);
+    {
+        let row_info = state.inputs.fetchFeatureAnnotations();
+        for (const [name, prefix] of Object.entries(all_prefixes)) {
+            let collected = df.writeHdf5DataFrame(row_info[name], prefix + "rowdata", { forceBuffer });
+            collected.self.metadata.is_child = true;
+            all_top_meta[name].summarized_experiment.row_data.resource.path = collected.self.metadata.path;
+            all_files.push(collected.self);
+            for (const x of collected.children) {
+                all_files.push(x);
+            }
+        }
+    }
 
     // Saving the count assay.
     for (const [m, prefix] of Object.entries(all_prefixes)) {
@@ -323,8 +311,18 @@ export async function dumpSingleCellExperiment(state, path, { forceBuffer = fals
         all_files.push(saved);
     }
 
-    // Saving extra metadata (including cluster labelling assignments).
+    // Saving extra metadata.
     all_metadata[main].cell_labelling = await state.cell_labelling.fetchResults();
+
+    {
+        let customs = state.custom_selections.fetchSelections({ copy: true, force: "Int32Array" });
+        if (reportOneIndex) {
+            for (const [k, v] of Object.entries(customs)) { // incrementing by 1, if requested.
+                v.forEach((x, i) => { v[i] = x + 1; });
+            }
+        }
+        all_metadata[main].custom_selections = customs;
+    }
 
     for (const [m, prefix] of Object.entries(all_prefixes)) {
         let saved = list.dumpList(all_metadata[m], prefix + "other");

--- a/src/dump/index.js
+++ b/src/dump/index.js
@@ -71,6 +71,9 @@ export async function saveSingleCellExperiment(state, name, { reportOneIndex = f
 /**
  * Save the per-gene analysis results into [**ArtifactDB** data frames](https://github.com/ArtifactDB/BiocObjectSchemas).
  * This includes the marker tables for the clusters and custom selections, as well as the variance modelling statistics from the feature selection step.
+ * Each data frames has the same order of rows as the SingleCellExperiment saved by {@linkcode saveSingleCellExperiment};
+ * for easier downstream use, we set the row names of each data frame to row names of the SingleCellExperiment
+ * (or if no row names are available, we set each data frame's row names to the first column of the `rowData`).
  *
  * @param {object} state - Existing analysis state containing results, after one or more runs of {@linkcode runAnalysis}.
  * @param {string} prefix - Prefix to attach to the path for each result.
@@ -83,9 +86,9 @@ export async function saveSingleCellExperiment(state, name, { reportOneIndex = f
  * @param {?directory} [options.directory=null] - Project directory in which to save the file components of the SingleCellExperiment.
  * Only used for Node.js; if supplied, it overrides any setting of `forceBuffer`.
  *
- * @return {Array} Array of objects where each object corresponds to a data frame of per-gene statistics, in the same order as the rows saved by {@linkcode saveSingleCellExperiment}.
- * These data frames are grouped by analysis step into `marker_detection`, `custom_selections` and `feature_selection`.
- * See {@linkcode saveSingleCellExperiment} for more details on the contents of each object.
+ * @return {Array} Array of objects where each object corresponds to a data frame of per-gene statistics.
+ * These data frames are grouped by analysis step, i.e., `marker_detection`, `custom_selections` and `feature_selection`.
+ * See {@linkcode saveSingleCellExperiment} for more details on the contents of each object inside the returned array.
  */
 export async function saveGenewiseResults(state, name, { includeMarkerDetection = true, includeCustomSelections = true, includeFeatureSelection = true, forceBuffer = null, directory = null } = {}) {
     let modalities = {};

--- a/src/dump/index.js
+++ b/src/dump/index.js
@@ -1,4 +1,5 @@
 import * as sce from "./SingleCellExperiment.js";
+import * as markers from "./markers.js";
 import * as adump from "./abstract/dump.js";
 import JSZip from "jszip";
 
@@ -8,12 +9,11 @@ import JSZip from "jszip";
  * The aim is to facilitate downstream analysis procedures that are not supported by **bakana** itself; 
  * for example, a bench scientist can do a first pass with **kana** before passing the results to a computational collaborator for deeper inspection.
  *
- * Note that all indices are 0-based and should be incremented by 1 before use in 1-based languages like R.
- * This involves the block assignments (indexing the block levels), the cluster assignments (indexing the marker results), and the custom selections (indexing the matrix columns).
- *
  * @param {object} state - Existing analysis state containing results, after one or more runs of {@linkcode runAnalysis}.
  * @param {string} name - Name of the SingleCellExperiment to be saved.
  * @param {object} [options={}] - Optional parameters.
+ * @param {boolean} [options.reportOneIndex=false] - Whether to report 1-based indices, for use in 1-based languages like R.
+ * Currently, this refers to the column indices of the custom selections reported in the SingleCellExperiment's metadata.
  * @param {boolean} [options.forceBuffer=true] - Whether to force all files to be loaded into memory as Uint8Array buffers.
  * @param {?directory} [options.directory=null] - Project directory in which to save the file components of the SingleCellExperiment.
  * Only used for Node.js; if supplied, it overrides any setting of `forceBuffer`.
@@ -31,13 +31,15 @@ import JSZip from "jszip";
  *   see [here](https://kanaverse.github.io/scran.js/global.html#readFile) to extract its contents and to clean up afterwards.
  * - If the function is called from Node.js and `directory` is supplied, `contents` is a string to a file path inside `directory`.
  *   This overrides any expectations from the setting of `forceBuffer` and is the most efficient approach for Node.js.
+ * 
+ * The SingleCellExperiment itself will be accessible from a top-level object at the path defined by `name`.
  */
-export async function saveSingleCellExperiment(state, name, { forceBuffer = null, directory = null } = {}) {
+export async function saveSingleCellExperiment(state, name, { reportOneIndex = false, forceBuffer = null, directory = null } = {}) {
     if (directory !== null) {
         forceBuffer = false;
     } 
 
-    let { metadata, files } = await sce.dumpSingleCellExperiment(state, name, { forceBuffer });
+    let { metadata, files } = await sce.dumpSingleCellExperiment(state, name, { forceBuffer, reportOneIndex });
     files.push({ metadata });
 
     // Added a redirection document.
@@ -55,6 +57,58 @@ export async function saveSingleCellExperiment(state, name, { forceBuffer = null
             }
         }
     });
+
+    await adump.attachMd5sums(files);
+
+    // Either dumping everything to file or returning all the buffers.
+    if (!forceBuffer && directory !== null) {
+        await adump.realizeDirectory(files, directory, name);
+    }
+
+    return files;
+}
+
+/**
+ * Save the per-gene analysis results into [**ArtifactDB** data frames](https://github.com/ArtifactDB/BiocObjectSchemas).
+ * This includes the marker tables for the clusters and custom selections, as well as the variance modelling statistics from the feature selection step.
+ *
+ * @param {object} state - Existing analysis state containing results, after one or more runs of {@linkcode runAnalysis}.
+ * @param {string} name - Name of the SingleCellExperiment to be saved.
+ * @param {object} [options={}] - Optional parameters.
+ * @param {boolean} [options.includeMarkerDetection=true] - Whether to save the marker detection results.
+ * @param {boolean} [options.includeCustomSelections=true] - Whether to save the custom selection results.
+ * @param {boolean} [options.includeFeatureSelection=true] - Whether to save the feature selection results.
+ * @param {boolean} [options.forceBuffer=true] - Whether to force all files to be loaded into memory as Uint8Array buffers.
+ * @param {?directory} [options.directory=null] - Project directory in which to save the file components of the SingleCellExperiment.
+ * Only used for Node.js; if supplied, it overrides any setting of `forceBuffer`.
+ *
+ * @return {Array} Array of objects where each object corresponds to a data frame of per-gene statistics, in the same order as the rows saved by {@linkcode saveSingleCellExperiment}.
+ * These data frames are grouped by analysis step into `marker_detection`, `custom_selections` and `feature_selection`.
+ * See {@linkcode saveSingleCellExperiment} for more details on the contents of each object.
+ */
+export async function saveGenewiseResults(state, name, { includeMarkerDetection = true, includeCustomSelections = true, includeFeatureSelection = true, forceBuffer = null, directory = null } = {}) {
+    let modalities = {};
+    let anno = state.inputs.fetchFeatureAnnotations();
+    for (const [k, v] of Object.entries(anno)) {
+        let rn = v.rowNames();
+        if (rn === null && v.numberOfColumns() > 0) {
+            rn = v.column(0);
+        }
+        modalities[k] = rn;
+    }
+
+    let files = [];
+    if (includeMarkerDetection) {
+        markers.dumpMarkerDetectionResults(state, modalities, name, files, forceBuffer);
+    }
+
+    if (includeCustomSelections) {
+        markers.dumpCustomSelectionResults(state, modalities, name, files, forceBuffer);
+    }
+
+    if (state.feature_selection.valid() && includeFeatureSelection) {
+        markers.dumpFeatureSelectionResults(state, modalities.RNA, name, files, forceBuffer);
+    }
 
     await adump.attachMd5sums(files);
 

--- a/src/dump/index.js
+++ b/src/dump/index.js
@@ -73,7 +73,8 @@ export async function saveSingleCellExperiment(state, name, { reportOneIndex = f
  * This includes the marker tables for the clusters and custom selections, as well as the variance modelling statistics from the feature selection step.
  *
  * @param {object} state - Existing analysis state containing results, after one or more runs of {@linkcode runAnalysis}.
- * @param {string} name - Name of the SingleCellExperiment to be saved.
+ * @param {string} prefix - Prefix to attach to the path for each result.
+ * This can contain subdirectories, or it can be an empty string.
  * @param {object} [options={}] - Optional parameters.
  * @param {boolean} [options.includeMarkerDetection=true] - Whether to save the marker detection results.
  * @param {boolean} [options.includeCustomSelections=true] - Whether to save the custom selection results.
@@ -97,7 +98,13 @@ export async function saveGenewiseResults(state, name, { includeMarkerDetection 
         modalities[k] = rn;
     }
 
+    // Stripping trailing slashes.
+    if (name.endsWith("/")) {
+        name = name.replace(/\/+$/, "");
+    }
+
     let files = [];
+
     if (includeMarkerDetection) {
         markers.dumpMarkerDetectionResults(state, modalities, name, files, forceBuffer);
     }

--- a/src/dump/markers.js
+++ b/src/dump/markers.js
@@ -1,19 +1,20 @@
 import * as bioc from "bioconductor";
+import * as df from "./DataFrame.js";
 
 const translate_effects = { "lfc": "lfc", "delta_detected": "deltaDetected", "auc": "auc", "cohen": "cohen" };
 
-export function dumpMarkerDetectionResults(state, modalities, all_rowdata) {
+export function dumpMarkerDetectionResults(state, modality_names, prefix, all_files, forceBuffer) {
     const translate_summary = { "min": 0, "mean": 1, "min_rank": 4 };
     const do_auc = state.marker_detection.fetchParameters().compute_auc;
+    let all_rowdata = state.inputs.fetchFeatureAnnotations();
 
-    for (const m of modalities) {
+    for (const [m, rn] of Object.entries(modality_names)) {
         let res = state.marker_detection.fetchResults()[m];
         let ngroups = res.numberOfGroups();
         let nfeatures = all_rowdata[m].numberOfRows();
-        let rdf = new bioc.DataFrame({}, { numberOfRows: nfeatures });
 
         for (var group = 0; group < ngroups; group++) {
-            let mdf = new bioc.DataFrame({}, { numberOfRows: nfeatures });
+            let mdf = new bioc.DataFrame({}, { numberOfRows: nfeatures, rowNames: rn });
 
             for (const x of [ "means", "detected" ]) {
                 mdf.$setColumn(x, res[x](group, { copy: "view" }));
@@ -28,34 +29,26 @@ export function dumpMarkerDetectionResults(state, modalities, all_rowdata) {
                 }
             }
 
-            rdf.$setColumn(String(group + 1), mdf); // incrementing to avoid cluster names starting from 0.
+            let new_name = group + 1; // incrementing to avoid cluster names starting from 0.
+            let collected = df.writeHdf5DataFrame(mdf, prefix + "/marker_detection/" + m + "/" + String(new_name), { forceBuffer });
+            all_files.push(collected.self);
         }
-
-        all_rowdata[m] = all_rowdata[m].setColumn("marker_detection", rdf);
     }
 
     return;
 }
 
-export function dumpCustomSelectionResults(state, modalities, main, all_rowdata, all_other_metadata) {
+export function dumpCustomSelectionResults(state, modality_names, prefix, all_files, forceBuffer) {
     const do_auc = state.custom_selections.fetchParameters().compute_auc;
-
     let all_sel = state.custom_selections.fetchSelections();
-    let processed_sel = { ...all_sel };
-    for (const [k, v] of Object.entries(processed_sel)) {
-        if (!(v instanceof Int32Array)) {
-            processed_sel[k] = new Int32Array(v);
-        }
-    }
-    all_other_metadata[main].custom_selections = processed_sel;
+    let all_rowdata = state.inputs.fetchFeatureAnnotations();
 
-    for (const m of modalities) {
+    for (const [m, rn] of Object.entries(modality_names)) {
         let nfeatures = all_rowdata[m].numberOfRows();
-        let rdf = new bioc.DataFrame({}, { numberOfRows: nfeatures });
 
         for (const sel of Object.keys(all_sel)) {
             let res = state.custom_selections.fetchResults(sel)[m];
-            let mdf = new bioc.DataFrame({}, { numberOfRows: nfeatures });
+            let mdf = new bioc.DataFrame({}, { numberOfRows: nfeatures, rowNames: rn });
 
             for (const x of [ "means", "detected" ]) {
                 mdf.$setColumn(x, res[x](1, { copy: "view" }));
@@ -68,8 +61,30 @@ export function dumpCustomSelectionResults(state, modalities, main, all_rowdata,
                 mdf.$setColumn(eff, res[trans_eff](1, { copy: "view" }));
             }
 
-            rdf.$setColumn(sel, mdf);
+            let collected = df.writeHdf5DataFrame(mdf, prefix + "/custom_selections/" + m + "/" + sel, { forceBuffer });
+            all_files.push(collected.self);
         }
-        all_rowdata[m] = all_rowdata[m].setColumn("custom_selections", rdf);
     }
+
+    return;
+}
+
+export function dumpFeatureSelectionResults(state, rna_names, prefix, all_files, forceBuffer) {
+    let res = state.feature_selection.fetchResults();
+    let fdf = new bioc.DataFrame(
+        {
+            mean: res.means({ copy: "view" }),
+            variance: res.variances({ copy: "view" }),
+            fitted: res.fitted({ copy: "view" }),
+            residual: res.residuals({ copy: "view" })
+        }, 
+        { 
+            columnOrder: [ "mean", "variance", "fitted", "residual" ],
+            rowNames: rna_names
+        }
+    );
+
+    let collected = df.writeHdf5DataFrame(fdf, prefix + "/feature_selection", { forceBuffer });
+    all_files.push(collected.self);
+    return;
 }

--- a/src/dump/markers.js
+++ b/src/dump/markers.js
@@ -30,7 +30,7 @@ export function dumpMarkerDetectionResults(state, modality_names, prefix, all_fi
             }
 
             let new_name = group + 1; // incrementing to avoid cluster names starting from 0.
-            let collected = df.writeHdf5DataFrame(mdf, prefix + "/marker_detection/" + m + "/" + String(new_name), { forceBuffer });
+            let collected = df.writeHdf5DataFrame(mdf, prefix + "marker_detection/" + m + "/" + String(new_name), { forceBuffer });
             all_files.push(collected.self);
         }
     }
@@ -61,7 +61,7 @@ export function dumpCustomSelectionResults(state, modality_names, prefix, all_fi
                 mdf.$setColumn(eff, res[trans_eff](1, { copy: "view" }));
             }
 
-            let collected = df.writeHdf5DataFrame(mdf, prefix + "/custom_selections/" + m + "/" + sel, { forceBuffer });
+            let collected = df.writeHdf5DataFrame(mdf, prefix + "custom_selections/" + m + "/" + sel, { forceBuffer });
             all_files.push(collected.self);
         }
     }
@@ -84,7 +84,7 @@ export function dumpFeatureSelectionResults(state, rna_names, prefix, all_files,
         }
     );
 
-    let collected = df.writeHdf5DataFrame(fdf, prefix + "/feature_selection", { forceBuffer });
+    let collected = df.writeHdf5DataFrame(fdf, prefix + "feature_selection", { forceBuffer });
     all_files.push(collected.self);
     return;
 }

--- a/tests/10X.test.js
+++ b/tests/10X.test.js
@@ -54,6 +54,7 @@ test("runAnalysis works correctly (10X)", async () => {
 
     // Check saving of results.
     await bakana.saveSingleCellExperiment(state, "10X", { directory: "miscellaneous/from-tests" });
+    await bakana.saveGenewiseResults(state, "10X_genes", { directory: "miscellaneous/from-tests" });
 
     // Check reloading of the parameters/datasets.
     {

--- a/tests/H5AD.test.js
+++ b/tests/H5AD.test.js
@@ -63,6 +63,7 @@ test("runAnalysis works correctly (H5AD)", async () => {
 
     // Check saving of results.
     await bakana.saveSingleCellExperiment(state, "H5AD", { directory: "miscellaneous/from-tests" });
+    await bakana.saveGenewiseResults(state, "H5AD_genes", { directory: "miscellaneous/from-tests" });
 
     // Check reloading of the parameters/datasets.
     {

--- a/tests/MatrixMarket.test.js
+++ b/tests/MatrixMarket.test.js
@@ -68,6 +68,7 @@ test("runAnalysis works correctly (MatrixMarket)", async () => {
 
     // Check saving of results.
     await bakana.saveSingleCellExperiment(state, "MatrixMarket", { directory: "miscellaneous/from-tests" });
+    await bakana.saveGenewiseResults(state, "MatrixMarket_genes", { directory: "miscellaneous/from-tests" });
 
     // Check reloading of the parameters/datasets.
     {

--- a/tests/adt.test.js
+++ b/tests/adt.test.js
@@ -86,6 +86,7 @@ test("runAnalysis works correctly (MatrixMarket)", async () => {
 
     // Check saving of results.
     await bakana.saveSingleCellExperiment(state, "adt", { directory: "miscellaneous/from-tests" });
+    await bakana.saveGenewiseResults(state, "adt_genes", { directory: "miscellaneous/from-tests" });
 
     // Release me!
     await bakana.freeAnalysis(state);

--- a/tests/combined.test.js
+++ b/tests/combined.test.js
@@ -64,6 +64,7 @@ test("multi-matrix analyses work correctly", async () => {
 
     // Check saving of results.
     await bakana.saveSingleCellExperiment(state, "combined", { directory: "miscellaneous/from-tests" });
+    await bakana.saveGenewiseResults(state, "combined_genes", { directory: "miscellaneous/from-tests" });
 
     // Check reloading of the parameters/datasets.
     {

--- a/tests/crispr.test.js
+++ b/tests/crispr.test.js
@@ -77,6 +77,7 @@ test("runAnalysis works correctly (10X)", async () => {
 
     // Check saving of results.
     await bakana.saveSingleCellExperiment(state, "crispr", { directory: "miscellaneous/from-tests" });
+    await bakana.saveGenewiseResults(state, "crispr_genes", { directory: "miscellaneous/from-tests" });
 
     // Release me!
     await bakana.freeAnalysis(state);

--- a/tests/custom.test.js
+++ b/tests/custom.test.js
@@ -81,7 +81,8 @@ test("addition, fetching and removal of custom selections works correctly", asyn
     }
 
     // Check saving of results.
-    await bakana.saveSingleCellExperiment(state, "custom", { directory: "miscellaneous/from-tests" });
+    await bakana.saveSingleCellExperiment(state, "custom", { directory: "miscellaneous/from-tests", reportOneIndex: true });
+    await bakana.saveGenewiseResults(state, "custom_genes", { directory: "miscellaneous/from-tests" });
 
     // Serialization and reloading works as expected.
     {

--- a/tests/se.test.js
+++ b/tests/se.test.js
@@ -69,6 +69,7 @@ test("runAnalysis works correctly (RDS containing SingleCellExperiment)", async 
 
     // Check saving of results.
     await bakana.saveSingleCellExperiment(state, "se", { directory: "miscellaneous/from-tests" });
+    await bakana.saveGenewiseResults(state, "se_results", { directory: "miscellaneous/from-tests" });
 
     // Check reloading of the parameters/datasets.
     {


### PR DESCRIPTION
This should make life a little easier for loading in clients, as we don't have to load all the marker tables at the same time.

We now dump the existing column annotations for posterity. We add prefixes in front of kana-computed fields to better distinguish between those and the existing fields.

To simplify matters, any blocking factor is always reported by converting the factor back to an array of its original levels. This avoids arguing about indices and such.

Custom selections now have a reportOneIndex option to specify whether they should be reported as 1-based indices, e.g., for use in R. We also report them as a boolean filter in the column data, for easier use in subsetting.